### PR TITLE
Swap mj library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 node_js:
-- '4'
-- '5'
-- '6'
 - stable
 sudo: false
 script:

--- a/bin/am2html
+++ b/bin/am2html
@@ -23,7 +23,7 @@
  *  limitations under the License.
  */
 
-var mjAPI = require("mathjax-node");
+var mjAPI = require("mathjax-node-sre");
 
 var argv = require("yargs")
   .demand(1).strict()

--- a/bin/am2htmlcss
+++ b/bin/am2htmlcss
@@ -23,7 +23,7 @@
  *  limitations under the License.
  */
 
-var mjAPI = require("mathjax-node");
+var mjAPI = require("mathjax-node-sre");
 
 var argv = require("yargs")
   .demand(1).strict()

--- a/bin/am2mml
+++ b/bin/am2mml
@@ -23,7 +23,7 @@
  *  limitations under the License.
  */
 
-var mjAPI = require("mathjax-node");
+var mjAPI = require("mathjax-node-sre");
 
 var argv = require("yargs")
   .demand(1).strict()

--- a/bin/am2svg
+++ b/bin/am2svg
@@ -23,7 +23,7 @@
  *  limitations under the License.
  */
 
-var mjAPI = require("mathjax-node");
+var mjAPI = require("mathjax-node-sre");
 
 var argv = require("yargs")
   .demand(1).strict()

--- a/bin/mml2html
+++ b/bin/mml2html
@@ -23,7 +23,7 @@
  *  limitations under the License.
  */
 
-var mjAPI = require("mathjax-node");
+var mjAPI = require("mathjax-node-sre");
 
 var argv = require("yargs")
   .demand(1).strict()

--- a/bin/mml2htmlcss
+++ b/bin/mml2htmlcss
@@ -23,7 +23,7 @@
  *  limitations under the License.
  */
 
-var mjAPI = require("mathjax-node");
+var mjAPI = require("mathjax-node-sre");
 
 var argv = require("yargs")
   .demand(1).strict()

--- a/bin/mml2mml
+++ b/bin/mml2mml
@@ -24,7 +24,7 @@
  *  limitations under the License.
  */
 
-var mjAPI = require("mathjax-node");
+var mjAPI = require("mathjax-node-sre");
 
 var argv = require("yargs")
   .demand(1).strict()

--- a/bin/mml2svg
+++ b/bin/mml2svg
@@ -23,7 +23,7 @@
  *  limitations under the License.
  */
 
-var mjAPI = require("mathjax-node");
+var mjAPI = require("mathjax-node-sre");
 
 var argv = require("yargs")
   .demand(1).strict()

--- a/bin/mml2svg-html5
+++ b/bin/mml2svg-html5
@@ -25,7 +25,7 @@
  *  limitations under the License.
  */
 
-var mjAPI = require("mathjax-node");
+var mjAPI = require("mathjax-node-sre");
 var fs = require('fs');
 var jsdom = require('jsdom').jsdom;
 

--- a/bin/tex2html
+++ b/bin/tex2html
@@ -23,7 +23,7 @@
  *  limitations under the License.
  */
 
-var mjAPI = require("mathjax-node");
+var mjAPI = require("mathjax-node-sre");
 
 var argv = require("yargs")
   .demand(1).strict()

--- a/bin/tex2htmlcss
+++ b/bin/tex2htmlcss
@@ -23,7 +23,7 @@
  *  limitations under the License.
  */
 
-var mjAPI = require("mathjax-node");
+var mjAPI = require("mathjax-node-sre");
 
 var argv = require("yargs")
   .demand(1).strict()

--- a/bin/tex2mml
+++ b/bin/tex2mml
@@ -23,7 +23,7 @@
  *  limitations under the License.
  */
 
-var mjAPI = require("mathjax-node");
+var mjAPI = require("mathjax-node-sre");
 
 var argv = require("yargs")
   .demand(1).strict()

--- a/bin/tex2svg
+++ b/bin/tex2svg
@@ -23,7 +23,7 @@
  *  limitations under the License.
  */
 
-var mjAPI = require("mathjax-node");
+var mjAPI = require("mathjax-node-sre");
 
 var argv = require("yargs")
   .demand(1).strict()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathjax-node-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CLI tools for calling mathjax-node",
   "keywords": [
     "mathjax-node",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "git://github.com/mathjax/mathjax-node-cli.git"
   },
   "dependencies": {
-    "mathjax-node": "1.0.0-beta.0",
+    "mathjax-node-sre": "*",
     "yargs": "3.*"
   },
   "scripts": {


### PR DESCRIPTION
Uses mathjax-node-sre instead of mathjax-node. 
This will get the speech to work (which we claim should work by default anyway).