### PR TITLE
--blacker option for tex2svg

### DIFF
--- a/bin/tex2svg
+++ b/bin/tex2svg
@@ -8,7 +8,7 @@
  *
  * ----------------------------------------------------------------------
  *
- *  Copyright (c) 2014 The MathJax Consortium
+ *  Copyright (c) 2014-2021 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@ var mjAPI = require("mathjax-node-sre");
 
 var argv = require("yargs")
   .demand(1).strict()
-    .usage("$0 [options] 'math' > file.svg")
-    .options({
+  .usage("$0 [options] 'math' > file.svg")
+  .options({
       inline: {
       boolean: true,
       describe: "process as in-line TeX"
@@ -46,6 +46,10 @@ var argv = require("yargs")
       default: "TeX",
       describe: "web font to use"
     },
+    blacker: {
+      default: 1,
+      describe: "character stroke width"
+    },
     ex: {
       default: 6,
       describe: "ex-size in pixels"
@@ -62,7 +66,7 @@ var argv = require("yargs")
   .argv;
 
 if (argv.font === "STIX") argv.font = "STIX-Web";
-mjAPI.config({MathJax: {SVG: {font: argv.font}}, extensions: argv.extensions});
+mjAPI.config({MathJax: {SVG: {font: argv.font, blacker: argv.blacker}}, extensions: argv.extensions});
 mjAPI.start();
 
 mjAPI.typeset({


### PR DESCRIPTION
This resolves issue https://github.com/mathjax/mathjax-node-cli/issues/15,
exposing the popular SVG configuration `blacker` as the option `--blacker` to the `tex2svg` command.